### PR TITLE
Add Redis service configuration in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
         
 services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+    command: redis-server --save 60 1 --loglevel warning
+
   backend:
     build: .
     container_name: backend-b


### PR DESCRIPTION
Added Redis service to docker-compose.yml.
Configured Redis with redis-server --save 60 1 --loglevel warning. Exposed port 6379 for external access.
Installed Redis in a Docker Compose environment.